### PR TITLE
Add basic image converter MVP

### DIFF
--- a/index.html
+++ b/index.html
@@ -1,0 +1,33 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="UTF-8">
+<title>Image Converter</title>
+<link rel="stylesheet" href="style.css">
+</head>
+<body>
+<h1>Image Converter</h1>
+<div id="drop-zone">Drop image here or click to upload</div>
+<input type="file" id="file-input" accept="image/*" hidden>
+<canvas id="canvas"></canvas>
+<div id="controls">
+<label for="aspect-ratio">Aspect:</label>
+<select id="aspect-ratio">
+<option value="free">Free</option>
+<option value="1:1">Square</option>
+<option value="16:9">16:9</option>
+<option value="4:3">4:3</option>
+</select>
+<label for="output-format">Format:</label>
+<select id="output-format">
+<option value="image/jpeg">JPEG</option>
+<option value="image/png">PNG</option>
+<option value="image/webp">WebP</option>
+</select>
+<label for="quality">Quality:</label>
+<input type="range" id="quality" min="0.1" max="1" step="0.1" value="0.92">
+<button id="download">Download</button>
+</div>
+<script type="module" src="src/main.js"></script>
+</body>
+</html>

--- a/src/converter.js
+++ b/src/converter.js
@@ -1,0 +1,7 @@
+export function convert(canvas, format, quality) {
+    return new Promise((resolve) => {
+        canvas.toBlob((blob) => {
+            resolve(blob);
+        }, format, quality);
+    });
+}

--- a/src/cropper.js
+++ b/src/cropper.js
@@ -1,0 +1,80 @@
+export class Cropper {
+    constructor(canvas, aspectSelect) {
+        this.canvas = canvas;
+        this.ctx = canvas.getContext('2d');
+        this.aspectSelect = aspectSelect;
+        this.image = null;
+        this.dragging = false;
+        this.startX = 0;
+        this.startY = 0;
+        this.crop = null;
+
+        this.canvas.addEventListener('mousedown', this.onDown.bind(this));
+        this.canvas.addEventListener('mousemove', this.onMove.bind(this));
+        this.canvas.addEventListener('mouseup', this.onUp.bind(this));
+    }
+
+    loadImage(img) {
+        this.image = img;
+        this.canvas.width = img.width;
+        this.canvas.height = img.height;
+        this.ctx.drawImage(img, 0, 0);
+        this.crop = null;
+    }
+
+    onDown(e) {
+        if (!this.image) return;
+        this.dragging = true;
+        const rect = this.canvas.getBoundingClientRect();
+        this.startX = e.clientX - rect.left;
+        this.startY = e.clientY - rect.top;
+        this.crop = { x: this.startX, y: this.startY, w: 0, h: 0 };
+    }
+
+    onMove(e) {
+        if (!this.dragging || !this.image) return;
+        const rect = this.canvas.getBoundingClientRect();
+        const endX = e.clientX - rect.left;
+        const endY = e.clientY - rect.top;
+        let w = endX - this.startX;
+        let h = endY - this.startY;
+        const aspect = this.aspectSelect.value;
+        if (aspect !== 'free') {
+            const [aw, ah] = aspect.split(':').map(Number);
+            if (Math.abs(w) > Math.abs(h)) {
+                h = Math.sign(h) * Math.abs(w) * ah / aw;
+            } else {
+                w = Math.sign(w) * Math.abs(h) * aw / ah;
+            }
+        }
+        this.crop.w = w;
+        this.crop.h = h;
+        this.redraw();
+    }
+
+    onUp() {
+        this.dragging = false;
+    }
+
+    redraw() {
+        if (!this.image) return;
+        this.ctx.clearRect(0, 0, this.canvas.width, this.canvas.height);
+        this.ctx.drawImage(this.image, 0, 0);
+        if (this.crop) {
+            this.ctx.strokeStyle = 'red';
+            this.ctx.lineWidth = 2;
+            this.ctx.strokeRect(this.crop.x, this.crop.y, this.crop.w, this.crop.h);
+        }
+    }
+
+    getCroppedImage() {
+        if (!this.image || !this.crop) return null;
+        const { x, y, w, h } = this.crop;
+        const canvas = document.createElement('canvas');
+        canvas.width = Math.abs(w);
+        canvas.height = Math.abs(h);
+        const ctx = canvas.getContext('2d');
+        ctx.drawImage(this.image, x, y, w, h, 0, 0, Math.abs(w), Math.abs(h));
+        return canvas;
+    }
+}

--- a/src/main.js
+++ b/src/main.js
@@ -1,0 +1,34 @@
+import { initUploader } from './uploader.js';
+import { Cropper } from './cropper.js';
+import { convert } from './converter.js';
+
+const dropZone = document.getElementById('drop-zone');
+const fileInput = document.getElementById('file-input');
+const canvas = document.getElementById('canvas');
+const aspectSelect = document.getElementById('aspect-ratio');
+const formatSelect = document.getElementById('output-format');
+const qualityInput = document.getElementById('quality');
+const downloadBtn = document.getElementById('download');
+
+const cropper = new Cropper(canvas, aspectSelect);
+
+initUploader(dropZone, fileInput, (img) => {
+    cropper.loadImage(img);
+});
+
+downloadBtn.addEventListener('click', async () => {
+    const cropped = cropper.getCroppedImage();
+    if (!cropped) {
+        alert('Please select an area to crop');
+        return;
+    }
+    const format = formatSelect.value;
+    const quality = parseFloat(qualityInput.value);
+    const blob = await convert(cropped, format, quality);
+    const url = URL.createObjectURL(blob);
+    const a = document.createElement('a');
+    a.href = url;
+    a.download = `image.${format.split('/')[1]}`;
+    a.click();
+    URL.revokeObjectURL(url);
+});

--- a/src/uploader.js
+++ b/src/uploader.js
@@ -1,0 +1,47 @@
+export function initUploader(dropZone, fileInput, onLoad) {
+    dropZone.addEventListener('click', () => fileInput.click());
+
+    ['dragenter', 'dragover'].forEach(eventName => {
+        dropZone.addEventListener(eventName, (e) => {
+            e.preventDefault();
+            dropZone.classList.add('hover');
+        });
+    });
+
+    ['dragleave', 'drop'].forEach(eventName => {
+        dropZone.addEventListener(eventName, (e) => {
+            e.preventDefault();
+            dropZone.classList.remove('hover');
+        });
+    });
+
+    dropZone.addEventListener('drop', (e) => {
+        const file = e.dataTransfer.files[0];
+        handleFile(file);
+    });
+
+    fileInput.addEventListener('change', () => {
+        handleFile(fileInput.files[0]);
+    });
+
+    function handleFile(file) {
+        if (!file) return;
+        const validTypes = ['image/jpeg', 'image/png', 'image/webp', 'image/gif', 'image/bmp'];
+        if (!validTypes.includes(file.type)) {
+            alert('Unsupported file type');
+            return;
+        }
+        const maxSize = 5 * 1024 * 1024;
+        if (file.size > maxSize) {
+            alert('File too large (max 5MB)');
+            return;
+        }
+        const reader = new FileReader();
+        reader.onload = () => {
+            const img = new Image();
+            img.onload = () => onLoad(img);
+            img.src = reader.result;
+        };
+        reader.readAsDataURL(file);
+    }
+}

--- a/style.css
+++ b/style.css
@@ -1,0 +1,30 @@
+body {
+    font-family: Arial, sans-serif;
+    margin: 20px;
+}
+
+#drop-zone {
+    border: 2px dashed #ccc;
+    padding: 20px;
+    text-align: center;
+    cursor: pointer;
+    margin-bottom: 10px;
+}
+
+#drop-zone.hover {
+    background-color: #f0f0f0;
+}
+
+canvas {
+    max-width: 100%;
+    border: 1px solid #ccc;
+    margin-top: 10px;
+}
+
+#controls {
+    margin-top: 10px;
+}
+
+#controls > * {
+    margin-right: 10px;
+}


### PR DESCRIPTION
## Summary
- scaffold browser-based image converter with drag-and-drop upload
- add cropping utility with aspect ratio options and format conversion
- style basic interface for image processing controls

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68a0593dc218832683b5ee831706ea05