### PR TITLE
Add premium subscription check and reorganize layout

### DIFF
--- a/index.html
+++ b/index.html
@@ -7,43 +7,61 @@
 </head>
 <body>
 <h1>Image Converter</h1>
-<div id="drop-zone">Drop image here or click to upload</div>
-<input type="file" id="file-input" accept="image/*" hidden>
-<canvas id="canvas"></canvas>
-<div id="controls">
-<label for="aspect-ratio">Aspect:</label>
-<select id="aspect-ratio">
-<option value="free">Free</option>
-<option value="1:1">Square</option>
-<option value="circle">Circle</option>
-<option value="16:9">16:9</option>
-<option value="4:3">4:3</option>
-</select>
-<label for="output-format">Format:</label>
-<select id="output-format">
-<option value="image/jpeg">JPEG</option>
-<option value="image/png">PNG</option>
-<option value="image/webp">WebP</option>
-</select>
-<label for="quality">Quality:</label>
-<input type="range" id="quality" min="0.1" max="1" step="0.1" value="0.92">
-<button id="download">Download</button>
+<div id="app">
+  <div id="editor">
+    <div id="drop-zone">Drop image here or click to upload</div>
+    <input type="file" id="file-input" accept="image/*" hidden>
+    <canvas id="canvas"></canvas>
+  </div>
+  <div id="sidebar">
+    <div id="controls">
+      <label for="aspect-ratio">Aspect:</label>
+      <select id="aspect-ratio">
+        <option value="free">Free</option>
+        <option value="1:1">Square</option>
+        <option value="circle">Circle</option>
+        <option value="16:9">16:9</option>
+        <option value="4:3">4:3</option>
+      </select>
+      <label for="output-format">Format:</label>
+      <select id="output-format">
+        <option value="image/jpeg">JPEG</option>
+        <option value="image/png">PNG</option>
+        <option value="image/webp">WebP</option>
+      </select>
+      <label for="quality">Quality:</label>
+      <input type="range" id="quality" min="0.1" max="1" step="0.1" value="0.92">
+      <button id="download">Download</button>
+    </div>
+    <details id="filter-controls">
+      <summary>Filters</summary>
+      <div class="filter"><label for="grayscale">Greyscale:</label>
+        <input type="range" id="grayscale" min="0" max="1" step="0.1" value="0"></div>
+      <div class="filter"><label for="brightness">Brightness:</label>
+        <input type="range" id="brightness" min="0" max="2" step="0.1" value="1"></div>
+      <div class="filter"><label for="contrast">Contrast:</label>
+        <input type="range" id="contrast" min="0" max="2" step="0.1" value="1"></div>
+      <div class="filter"><label for="saturation">Saturation:</label>
+        <input type="range" id="saturation" min="0" max="2" step="0.1" value="1"></div>
+      <div class="filter"><label for="opacity">Opacity:</label>
+        <input type="range" id="opacity" min="0" max="1" step="0.1" value="1"></div>
+      <div class="filter"><label for="blur">Blur:</label>
+        <input type="range" id="blur" min="0" max="10" step="1" value="0"></div>
+    </details>
+    <a id="upgrade" class="button" href="php/payment.php">Upgrade to Premium</a>
+  </div>
 </div>
-<details id="filter-controls">
-<summary>Filters</summary>
-<div class="filter"><label for="grayscale">Greyscale:</label>
-<input type="range" id="grayscale" min="0" max="1" step="0.1" value="0"></div>
-<div class="filter"><label for="brightness">Brightness:</label>
-<input type="range" id="brightness" min="0" max="2" step="0.1" value="1"></div>
-<div class="filter"><label for="contrast">Contrast:</label>
-<input type="range" id="contrast" min="0" max="2" step="0.1" value="1"></div>
-<div class="filter"><label for="saturation">Saturation:</label>
-<input type="range" id="saturation" min="0" max="2" step="0.1" value="1"></div>
-<div class="filter"><label for="opacity">Opacity:</label>
-<input type="range" id="opacity" min="0" max="1" step="0.1" value="1"></div>
-<div class="filter"><label for="blur">Blur:</label>
-<input type="range" id="blur" min="0" max="10" step="1" value="0"></div>
-</details>
 <script type="module" src="src/main.js"></script>
+<script>
+fetch('php/check_subscription.php')
+  .then(r => r.json())
+  .then(data => {
+    if (data.premium) {
+      document.getElementById('upgrade').style.display = 'none';
+    } else {
+      document.getElementById('filter-controls').style.display = 'none';
+    }
+  });
+</script>
 </body>
 </html>

--- a/php/check_subscription.php
+++ b/php/check_subscription.php
@@ -1,0 +1,18 @@
+<?php
+require 'config.php';
+require 'auth.php';
+header('Content-Type: application/json');
+
+$response = ['premium' => false];
+$userId = current_user_id();
+if ($userId) {
+    $stmt = $pdo->prepare('SELECT status FROM billing_subscriptions WHERE user_id = ? AND status = "active" ORDER BY id DESC LIMIT 1');
+    $stmt->execute([$userId]);
+    $sub = $stmt->fetch();
+    if ($sub && $sub['status'] === 'active') {
+        $response['premium'] = true;
+    }
+}
+
+echo json_encode($response);
+?>

--- a/style.css
+++ b/style.css
@@ -3,6 +3,23 @@ body {
     margin: 20px;
 }
 
+#app {
+    display: flex;
+    gap: 20px;
+    align-items: flex-start;
+}
+
+#editor {
+    flex: 2;
+}
+
+#sidebar {
+    flex: 1;
+    display: flex;
+    flex-direction: column;
+    gap: 20px;
+}
+
 #drop-zone {
     border: 2px dashed #ccc;
     padding: 20px;
@@ -31,6 +48,20 @@ canvas {
 
 #filter-controls {
     margin-top: 10px;
+}
+
+#upgrade {
+    margin-top: auto;
+}
+
+.button {
+    display: inline-block;
+    padding: 10px 20px;
+    background-color: #007bff;
+    color: #fff;
+    text-decoration: none;
+    text-align: center;
+    border-radius: 4px;
 }
 
 #filter-controls .filter {


### PR DESCRIPTION
## Summary
- reorganize layout into editor and sidebar to match mockup
- add upgrade to premium button and hide filters for free accounts
- add PHP endpoint to check subscription status

## Testing
- `php -l php/check_subscription.php`
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68a10477c968832698d158b77c3f3540