### PR TITLE
Show disabled premium filters with upgrade prompt

### DIFF
--- a/index.html
+++ b/index.html
@@ -72,7 +72,19 @@ fetch('check_subscription.php')
     if (data.premium) {
       document.getElementById('upgrade').style.display = 'none';
     } else {
-      document.getElementById('filter-controls').style.display = 'none';
+      const filterControls = document.getElementById('filter-controls');
+      filterControls.setAttribute('open', '');
+      filterControls.querySelectorAll('input').forEach(input => input.disabled = true);
+      filterControls.querySelectorAll('.filter').forEach(filter => {
+        filter.style.position = 'relative';
+        const lock = document.createElement('div');
+        lock.className = 'feature-lock';
+        lock.title = 'Upgrade to access';
+        lock.addEventListener('click', () => {
+          window.open('payment.php', '_blank');
+        });
+        filter.appendChild(lock);
+      });
     }
   });
 </script>

--- a/style.css
+++ b/style.css
@@ -108,6 +108,18 @@ canvas {
     display: flex;
     align-items: center;
     margin: 5px 0;
+    position: relative;
+}
+
+.feature-lock {
+    position: absolute;
+    top: 0;
+    left: 0;
+    right: 0;
+    bottom: 0;
+    cursor: not-allowed;
+    background-color: rgba(255, 255, 255, 0.6);
+    z-index: 1;
 }
 
 #filter-controls .filter label {


### PR DESCRIPTION
## Summary
- Keep premium filters visible for free users but disable their inputs
- Add overlay with tooltip and click handler to open upgrade page in new window
- Style overlay to show deactivated state

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68a2663a25d08326acd491a5f05d19b7